### PR TITLE
Fix code misspelling

### DIFF
--- a/lib/hibp/client.rb
+++ b/lib/hibp/client.rb
@@ -117,7 +117,7 @@ module Hibp
     # @param add_padding [Boolean] -
     #   Pads out the response with a random number of fake requests, to prevent
     #   anyone looking at the responses from guessing what the hash prefix was.
-    #   
+    #
     #
     # @note The API will respond with include the suffix of every hash beginning
     #       with the specified password prefix(five first chars of the password hash),
@@ -153,7 +153,7 @@ module Hibp
     end
 
     def resolve_parser(service)
-      breach_services = %i[breach breaches account_bereaches]
+      breach_services = %i[breach breaches account_breaches]
 
       case service
       when ->(n) { breach_services.include?(n) }

--- a/spec/hibp/client_spec.rb
+++ b/spec/hibp/client_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Hibp::Client do
     it { expect(subject.endpoint).to eq('https://haveibeenpwned.com/api/v3/breach/test') }
 
     it { expect(subject.headers).to eq('hibp-api-key' => '') }
+
+    it { expect(subject.instance_variable_get('@parser')).to be_a(Hibp::Parsers::Breach) }
   end
 
   describe '#account_breaches' do
@@ -35,6 +37,8 @@ RSpec.describe Hibp::Client do
     it { expect(subject.endpoint).to eq('https://haveibeenpwned.com/api/v3/breachedaccount/test%40example.com') }
 
     it { expect(subject.headers).to eq('hibp-api-key' => '') }
+
+    it { expect(subject.instance_variable_get('@parser')).to be_a(Hibp::Parsers::Breach) }
   end
 
   describe '#data_classes' do


### PR DESCRIPTION
### Description

Fix code misspelling which is causing the gem cannot get correctly the "parser" object for `account_breaches` requests.